### PR TITLE
server ports and url change to support render defaults

### DIFF
--- a/monitor/backend/main.go
+++ b/monitor/backend/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/prateeks007/PulseWatch/monitor/backend/models"
@@ -150,9 +151,16 @@ func main() {
 	})
 
 	// Start the API server in a separate goroutine
+
 	go func() {
-		fmt.Println("Starting API server on http://localhost:3000")
-		if err := app.Listen(":3000"); err != nil {
+		port := os.Getenv("PORT")
+		if port == "" {
+			port = "3000" // fallback for local dev
+		}
+		addr := "0.0.0.0:" + port
+
+		fmt.Printf("Starting API server on http://%s\n", addr)
+		if err := app.Listen(addr); err != nil {
 			fmt.Printf("API server error: %v\n", err)
 		}
 	}()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The server now automatically uses the `PORT` environment variable to determine which port to listen on, defaulting to 3000 if not set.
  * The server listens on all network interfaces, making it accessible from external devices.
  * The startup message now displays the actual address and port the server is using.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->